### PR TITLE
Add in support for FIDO devices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,30 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+===========================================================================
+
+Below is a summary of the external licensing used in this project.
+
+Upstream-Name: salt
+Upstream-Contact: salt-users@googlegroups.com
+Source: https://github.com/saltstack/salt
+
+File: v1.4.0/butane-v1.4.0.json
+Line: 1000
+File: v1.5.0-experimental/butane-v1.5.0-experimental.json
+Line: 1020
+
+Copyright: 2022 SaltStack Team
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.

--- a/v1.4.0/butane-v1.4.0.json
+++ b/v1.4.0/butane-v1.4.0.json
@@ -997,7 +997,7 @@
                     "items": {
                       "oneOf": [
                         {
-                          "pattern": "^(ssh-rsa AAAAB3NzaC1yc2|ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT|ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD|ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj|ssh-ed25519 AAAAC3NzaC1lZDI1NTE5|ssh-dss AAAAB3NzaC1kc3)[0-9A-Za-z+/]+[=]{0,3}( .*)?$"
+                          "pattern": "((.*)\\s)?((?:sk-)?(?:ssh|ecdsa)-[a-z0-9@.-]+)\\s([a-zA-Z0-9+/]+={0,2})(\\s(.*))?"
                         }
                       ]
                     }

--- a/v1.4.0/testconfig.bu
+++ b/v1.4.0/testconfig.bu
@@ -153,7 +153,13 @@ passwd:
   users:
     - name: user1
       ssh_authorized_keys:
-        - ssh-rsa AAAAB3NzaC1yc2andmore
+        - ssh-rsa AAAAB3NzaC1yc2asdfas test@openssh.com
+        - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT asdfasdf
+        - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD asdfasdf
+        - ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj test@example.net
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 testing
+        - sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAI yubikey 5 nfc
+        - ssh-dss AAAAB3NzaC1kc3 oldkey@example.com
       password_hash: $y$j9T$aUmgEDoFIDPhGxEe2FUjc/$C5A...
       home_dir: /home/user1
       no_create_home: true

--- a/v1.5.0-experimental/butane-v1.5.0-experimental.json
+++ b/v1.5.0-experimental/butane-v1.5.0-experimental.json
@@ -1017,7 +1017,7 @@
                     "items": {
                       "oneOf": [
                         {
-                          "pattern": "^(ssh-rsa AAAAB3NzaC1yc2|ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT|ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD|ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj|ssh-ed25519 AAAAC3NzaC1lZDI1NTE5|ssh-dss AAAAB3NzaC1kc3)[0-9A-Za-z+/]+[=]{0,3}( .*)?$"
+                          "pattern": "((.*)\\s)?((?:sk-)?(?:ssh|ecdsa)-[a-z0-9@.-]+)\\s([a-zA-Z0-9+/]+={0,2})(\\s(.*))?"
                         }
                       ]
                     }

--- a/v1.5.0-experimental/testconfig.bu
+++ b/v1.5.0-experimental/testconfig.bu
@@ -153,9 +153,15 @@ passwd:
   users:
     - name: user1
       ssh_authorized_keys:
-        - ssh-rsa AAAAB3NzaC1yc2andmore
+        - ssh-rsa AAAAB3NzaC1yc2asdfas test@openssh.com
+        - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT asdfasdf
+        - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD asdfasdf
+        - ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj test@example.net
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 testing
+        - sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAI yubikey 5 nfc
+        - ssh-dss AAAAB3NzaC1kc3 oldkey@example.com
       password_hash: $y$j9T$aUmgEDoFIDPhGxEe2FUjc/$C5A...
-      home_dir: /home/user1
+      home_dir: /home/user1#
       no_create_home: true
       groups:
         - wheel


### PR DESCRIPTION
This PR adds in support for FIDO/U2F keys.
OpenSSH added support for FIDO/U2F hardware authenticators in version 8.2+
https://www.openssh.com/txt/release-8.2

This PR uses a regex from the Salt project which is licensed under Apache-2.0:
https://github.com/saltstack/salt/blob/master/salt/modules/ssh.py#L172

You can see the regex in action here: https://regex101.com/r/51jm6u/1

It also fixes the regex so it will support comments and email addresses correctly.