### PR TITLE
Butane Schema for Flatcar linux v1.1.0

### DIFF
--- a/Butane-Schema-dev.json
+++ b/Butane-Schema-dev.json
@@ -44,7 +44,11 @@
       },
       {
         "if": { 
-          "properties": { "variant": { "const": "fcos" } }
+          "properties": {
+            "variant": {
+              "const": "fcos"
+              }
+            }
         },
         "then": {
           "properties": {

--- a/Butane-Schema-dev.json
+++ b/Butane-Schema-dev.json
@@ -21,16 +21,45 @@
     "version": {
       "$id": "#/properties/version",
       "type": "string",
-      "title": "version (string):",
-      "enum": [
-         "1.1.0",
-         "1.4.0",
-         "1.5.0",
-         "1.6.0"
-      ],
-      "default": "1.6.0"
+      "title": "version (string):"
     }
   },
+	"allOf": [
+		{
+			"if": { 
+				"properties": {
+						"variant": {
+								"const": "flatcar"
+							}
+						}
+         },
+				"then": {
+					"properties": {
+							"version": {
+								"enum": ["1.1.0"],
+								"default": "1.1.0"
+							}
+					}
+				}
+      },
+      {
+				"if": { 
+					"properties": { "variant": { "const": "fcos" } }
+				},
+				"then": {
+					"properties": {
+							"version": {
+								"enum": [
+										"1.4.0",
+										"1.5.0",
+										"1.6.0"
+								],
+								"default": "1.6.0"
+							}
+					}
+				}
+		}
+  ],
   "oneOf": [
     {
       "allOf": [

--- a/Butane-Schema-dev.json
+++ b/Butane-Schema-dev.json
@@ -24,41 +24,41 @@
       "title": "version (string):"
     }
   },
-	"allOf": [
-		{
-			"if": { 
-				"properties": {
-						"variant": {
-								"const": "flatcar"
-							}
-						}
+  "allOf": [
+    {
+      "if": { 
+        "properties": {
+            "variant": {
+                "const": "flatcar"
+              }
+            }
          },
-				"then": {
-					"properties": {
-							"version": {
-								"enum": ["1.1.0"],
-								"default": "1.1.0"
-							}
-					}
-				}
+        "then": {
+          "properties": {
+              "version": {
+                "enum": ["1.1.0"],
+                "default": "1.1.0"
+              }
+          }
+        }
       },
       {
-				"if": { 
-					"properties": { "variant": { "const": "fcos" } }
-				},
-				"then": {
-					"properties": {
-							"version": {
-								"enum": [
-										"1.4.0",
-										"1.5.0",
-										"1.6.0"
-								],
-								"default": "1.6.0"
-							}
-					}
-				}
-		}
+        "if": { 
+          "properties": { "variant": { "const": "fcos" } }
+        },
+        "then": {
+          "properties": {
+              "version": {
+                "enum": [
+                    "1.4.0",
+                    "1.5.0",
+                    "1.6.0"
+                ],
+                "default": "1.6.0"
+              }
+          }
+        }
+    }
   ],
   "oneOf": [
     {

--- a/Butane-Schema-dev.json
+++ b/Butane-Schema-dev.json
@@ -69,6 +69,9 @@
       "allOf": [
         {
           "properties": {
+            "variant": {
+              "const": "fcos"
+            },
             "version": {
               "const": "1.4.0"
             }
@@ -83,6 +86,9 @@
       "allOf": [
         {
           "properties": {
+            "variant": {
+              "const": "fcos"
+            },
             "version": {
               "const": "1.5.0"
             }
@@ -97,6 +103,9 @@
       "allOf": [
         {
           "properties": {
+            "variant": {
+              "const": "fcos"
+            },
             "version": {
               "const": "1.6.0"
             }

--- a/Butane-Schema-dev.json
+++ b/Butane-Schema-dev.json
@@ -11,7 +11,7 @@
       "$id": "#/properties/variant",
       "type": "string",
       "title": "variant (string):",
-      "description": "Used to differentiate configs for different operating systems. Must be fcos for this specification.",
+      "description": "Used to differentiate configs for different operating systems.",
       "enum": [
          "fcos",
          "flatcar"
@@ -26,111 +26,105 @@
   },
   "allOf": [
     {
-      "if": { 
-        "properties": {
-            "variant": {
-                "const": "flatcar"
-              }
-            }
-         },
-        "then": {
-          "properties": {
-              "version": {
-                "enum": ["1.1.0"],
-                "default": "1.1.0"
-              }
-          }
-        }
-      },
-      {
-        "if": { 
-          "properties": {
-            "variant": {
-              "const": "fcos"
-              }
-            }
-        },
-        "then": {
-          "properties": {
-              "version": {
-                "enum": [
-                    "1.4.0",
-                    "1.5.0",
-                    "1.6.0"
-                ],
-                "default": "1.6.0"
-              }
-          }
-        }
-    }
-  ],
-  "oneOf": [
-    {
-      "allOf": [
+      "oneOf": [
         {
           "properties": {
             "variant": {
               "const": "fcos"
             },
             "version": {
-              "const": "1.4.0"
+              "enum": [
+                "1.4.0",
+                "1.5.0",
+                "1.6.0"
+              ],
+              "default": "1.6.0"
             }
           }
         },
-        {
-          "$ref": "./v1.4.0/butane-v1.4.0.json"
-        }
-      ]
-    },
-    {
-      "allOf": [
         {
           "properties": {
             "variant": {
-              "const": "fcos"
+              "const": "flatcar"
             },
             "version": {
-              "const": "1.5.0"
+              "enum": ["1.1.0"],
+              "default": "1.1.0"
             }
           }
-        },
-        {
-          "$ref": "./v1.5.0/butane-v1.5.0.json"
         }
       ]
     },
     {
-      "allOf": [
+      "oneOf": [
         {
-          "properties": {
-            "variant": {
-              "const": "fcos"
+          "allOf": [
+            {
+              "properties": {
+                "variant": {
+                  "const": "fcos"
+                },
+                "version": {
+                  "const": "1.4.0"
+                }
+              }
             },
-            "version": {
-              "const": "1.6.0"
+            {
+              "$ref": "./v1.4.0/butane-v1.4.0.json"
             }
-          }
+          ]
         },
         {
-          "$ref": "./v1.6.0/butane-v1.6.0.json"
-        }
-      ]
-    },
-    {
-      "allOf": [
-         {
-            "properties": {
-               "variant": {
-                  "const": "flatcar"
-               },
-               "version": {
-                  "const": "1.1.0"
-               }
+          "allOf": [
+            {
+              "properties": {
+                "variant": {
+                  "const": "fcos"
+                },
+                "version": {
+                  "const": "1.5.0"
+                }
+              }
+            },
+            {
+              "$ref": "./v1.5.0/butane-v1.5.0.json"
             }
-         },
-         {
-            "$ref": "./flatcar-v1.1.0/butane-flatcar-v1.1.0.json"
-         }
+          ]
+        },
+        {
+          "allOf": [
+            {
+              "properties": {
+                "variant": {
+                  "const": "fcos"
+                },
+                "version": {
+                  "const": "1.6.0"
+                }
+              }
+            },
+            {
+              "$ref": "./v1.6.0/butane-v1.6.0.json"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+                "properties": {
+                  "variant": {
+                      "const": "flatcar"
+                  },
+                  "version": {
+                      "const": "1.1.0"
+                  }
+                }
+            },
+            {
+                "$ref": "./flatcar-v1.1.0/butane-flatcar-v1.1.0.json"
+            }
+          ]
+        }
       ]
     }
   ]

--- a/Butane-Schema-dev.json
+++ b/Butane-Schema-dev.json
@@ -12,14 +12,22 @@
       "type": "string",
       "title": "variant (string):",
       "description": "Used to differentiate configs for different operating systems. Must be fcos for this specification.",
-      "enum": ["fcos"],
+      "enum": [
+         "fcos",
+         "flatcar"
+      ],
       "default": "fcos"
     },
     "version": {
       "$id": "#/properties/version",
       "type": "string",
       "title": "version (string):",
-      "enum": ["1.4.0", "1.5.0", "1.6.0"],
+      "enum": [
+         "1.1.0",
+         "1.4.0",
+         "1.5.0",
+         "1.6.0"
+      ],
       "default": "1.6.0"
     }
   },
@@ -64,6 +72,23 @@
         {
           "$ref": "./v1.6.0/butane-v1.6.0.json"
         }
+      ]
+    },
+    {
+      "allOf": [
+         {
+            "properties": {
+               "variant": {
+                  "const": "flatcar"
+               },
+               "version": {
+                  "const": "1.1.0"
+               }
+            }
+         },
+         {
+            "$ref": "./flatcar-v1.1.0/butane-flatcar-v1.1.0.json"
+         }
       ]
     }
   ]

--- a/Butane-Schema-main.json
+++ b/Butane-Schema-main.json
@@ -70,7 +70,7 @@
               }
             },
             {
-              "$ref": "./v1.4.0/butane-v1.4.0.json"
+              "$ref": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/main/v1.4.0/butane-v1.4.0.json"
             }
           ]
         },
@@ -87,7 +87,7 @@
               }
             },
             {
-              "$ref": "./v1.5.0/butane-v1.5.0.json"
+              "$ref": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/main/v1.5.0/butane-v1.5.0.json"
             }
           ]
         },
@@ -104,7 +104,7 @@
               }
             },
             {
-              "$ref": "./v1.6.0/butane-v1.6.0.json"
+              "$ref": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/main/v1.6.0/butane-v1.6.0.json"
             }
           ]
         },
@@ -121,7 +121,7 @@
                 }
             },
             {
-                "$ref": "./flatcar-v1.1.0/butane-flatcar-v1.1.0.json"
+                "$ref": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/main/flatcar-v1.1.0/butane-flatcar-v1.1.0.json"
             }
           ]
         }

--- a/Butane-Schema-main.json
+++ b/Butane-Schema-main.json
@@ -6,63 +6,124 @@
   "type": "object",
   "required": ["variant", "version"],
 
-  "properties": {
+ "properties": {
     "variant": {
       "$id": "#/properties/variant",
       "type": "string",
       "title": "variant (string):",
-      "description": "Used to differentiate configs for different operating systems. Must be fcos for this specification.",
-      "enum": ["fcos"],
+      "description": "Used to differentiate configs for different operating systems.",
+      "enum": [
+         "fcos",
+         "flatcar"
+      ],
       "default": "fcos"
     },
     "version": {
       "$id": "#/properties/version",
       "type": "string",
-      "title": "version (string):",
-      "enum": ["1.4.0", "1.5.0", "1.6.0"],
-      "default": "1.6.0"
+      "title": "version (string):"
     }
   },
-  "oneOf": [
+  "allOf": [
     {
-      "allOf": [
+      "oneOf": [
         {
           "properties": {
+            "variant": {
+              "const": "fcos"
+            },
             "version": {
-              "const": "1.4.0"
+              "enum": [
+                "1.4.0",
+                "1.5.0",
+                "1.6.0"
+              ],
+              "default": "1.6.0"
             }
           }
         },
         {
-          "$ref": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/main/v1.4.0/butane-v1.4.0.json"
+          "properties": {
+            "variant": {
+              "const": "flatcar"
+            },
+            "version": {
+              "enum": ["1.1.0"],
+              "default": "1.1.0"
+            }
+          }
         }
       ]
     },
     {
-      "allOf": [
+      "oneOf": [
         {
-          "properties": {
-            "version": {
-              "const": "1.5.0"
+          "allOf": [
+            {
+              "properties": {
+                "variant": {
+                  "const": "fcos"
+                },
+                "version": {
+                  "const": "1.4.0"
+                }
+              }
+            },
+            {
+              "$ref": "./v1.4.0/butane-v1.4.0.json"
             }
-          }
+          ]
         },
         {
-          "$ref": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/main/v1.5.0/butane-v1.5.0.json"
-        }
-      ]
-    },
-    {
-      "allOf": [
-        {
-          "properties": {
-            "version": {
-              "const": "1.6.0"
+          "allOf": [
+            {
+              "properties": {
+                "variant": {
+                  "const": "fcos"
+                },
+                "version": {
+                  "const": "1.5.0"
+                }
+              }
+            },
+            {
+              "$ref": "./v1.5.0/butane-v1.5.0.json"
             }
-          }
+          ]
         },
         {
-          "$ref": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/main/v1.6.0/butane-v1.6.0.json"
+          "allOf": [
+            {
+              "properties": {
+                "variant": {
+                  "const": "fcos"
+                },
+                "version": {
+                  "const": "1.6.0"
+                }
+              }
+            },
+            {
+              "$ref": "./v1.6.0/butane-v1.6.0.json"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+                "properties": {
+                  "variant": {
+                      "const": "flatcar"
+                  },
+                  "version": {
+                      "const": "1.1.0"
+                  }
+                }
+            },
+            {
+                "$ref": "./flatcar-v1.1.0/butane-flatcar-v1.1.0.json"
+            }
+          ]
         }
       ]
     }

--- a/Butane-Schema.json
+++ b/Butane-Schema.json
@@ -70,7 +70,7 @@
               }
             },
             {
-              "$ref": "./v1.4.0/butane-v1.4.0.json"
+              "$ref": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/Release/v1.4.0/butane-v1.4.0.json"
             }
           ]
         },
@@ -87,7 +87,7 @@
               }
             },
             {
-              "$ref": "./v1.5.0/butane-v1.5.0.json"
+              "$ref": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/Release/v1.5.0/butane-v1.5.0.json"
             }
           ]
         },
@@ -104,7 +104,7 @@
               }
             },
             {
-              "$ref": "./v1.6.0/butane-v1.6.0.json"
+              "$ref": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/Release/v1.6.0/butane-v1.6.0.json"
             }
           ]
         },
@@ -121,7 +121,7 @@
                 }
             },
             {
-                "$ref": "./flatcar-v1.1.0/butane-flatcar-v1.1.0.json"
+                "$ref": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/Release/flatcar-v1.1.0/butane-flatcar-v1.1.0.json"
             }
           ]
         }

--- a/Butane-Schema.json
+++ b/Butane-Schema.json
@@ -6,63 +6,124 @@
   "type": "object",
   "required": ["variant", "version"],
 
-  "properties": {
+"properties": {
     "variant": {
       "$id": "#/properties/variant",
       "type": "string",
       "title": "variant (string):",
-      "description": "Used to differentiate configs for different operating systems. Must be fcos for this specification.",
-      "enum": ["fcos"],
+      "description": "Used to differentiate configs for different operating systems.",
+      "enum": [
+         "fcos",
+         "flatcar"
+      ],
       "default": "fcos"
     },
     "version": {
       "$id": "#/properties/version",
       "type": "string",
-      "title": "version (string):",
-      "enum": ["1.4.0", "1.5.0", "1.6.0"],
-      "default": "1.6.0"
+      "title": "version (string):"
     }
   },
-  "oneOf": [
+  "allOf": [
     {
-      "allOf": [
+      "oneOf": [
         {
           "properties": {
+            "variant": {
+              "const": "fcos"
+            },
             "version": {
-              "const": "1.4.0"
+              "enum": [
+                "1.4.0",
+                "1.5.0",
+                "1.6.0"
+              ],
+              "default": "1.6.0"
             }
           }
         },
         {
-          "$ref": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/Release/v1.4.0/butane-v1.4.0.json"
+          "properties": {
+            "variant": {
+              "const": "flatcar"
+            },
+            "version": {
+              "enum": ["1.1.0"],
+              "default": "1.1.0"
+            }
+          }
         }
       ]
     },
     {
-      "allOf": [
+      "oneOf": [
         {
-          "properties": {
-            "version": {
-              "const": "1.5.0"
+          "allOf": [
+            {
+              "properties": {
+                "variant": {
+                  "const": "fcos"
+                },
+                "version": {
+                  "const": "1.4.0"
+                }
+              }
+            },
+            {
+              "$ref": "./v1.4.0/butane-v1.4.0.json"
             }
-          }
+          ]
         },
         {
-          "$ref": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/Release/v1.5.0/butane-v1.5.0.json"
-        }
-      ]
-    },
-    {
-      "allOf": [
-        {
-          "properties": {
-            "version": {
-              "const": "1.6.0"
+          "allOf": [
+            {
+              "properties": {
+                "variant": {
+                  "const": "fcos"
+                },
+                "version": {
+                  "const": "1.5.0"
+                }
+              }
+            },
+            {
+              "$ref": "./v1.5.0/butane-v1.5.0.json"
             }
-          }
+          ]
         },
         {
-          "$ref": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/Release/v1.6.0/butane-v1.6.0.json"
+          "allOf": [
+            {
+              "properties": {
+                "variant": {
+                  "const": "fcos"
+                },
+                "version": {
+                  "const": "1.6.0"
+                }
+              }
+            },
+            {
+              "$ref": "./v1.6.0/butane-v1.6.0.json"
+            }
+          ]
+        },
+        {
+          "allOf": [
+            {
+                "properties": {
+                  "variant": {
+                      "const": "flatcar"
+                  },
+                  "version": {
+                      "const": "1.1.0"
+                  }
+                }
+            },
+            {
+                "$ref": "./flatcar-v1.1.0/butane-flatcar-v1.1.0.json"
+            }
+          ]
         }
       ]
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Butane-Schemas
 
-Butane Schemas that helps creating Butane files for [Fedora Coreos](https://fedoraproject.org/fr/coreos/)
+Butane Schemas that helps creating Butane files for [Fedora Coreos](https://fedoraproject.org/fr/coreos/) and [Flatcar Linux](https://www.flatcar.org)
 
 This json Schema that can be used as a helper to write a [butane config file](https://docs.fedoraproject.org/en-US/fedora-coreos/producing-ign/#_configuration_process) according to [its specifications](https://coreos.github.io/butane/specs/)
 

--- a/flatcar-v1.1.0/butane-flatcar-v1.1.0.json
+++ b/flatcar-v1.1.0/butane-flatcar-v1.1.0.json
@@ -3,8 +3,8 @@
   "$id": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/Release/flatcar-v1.1.0/butane-flatcar-v1.1.0.json#",
   "$comment": "Sources: https://github.com/Relativ-IT/Butane-Schemas/tree/Release/flatcar-v1.1.0",
   "type": "object",
-  "title": "Fedora Coreos Butane Schema",
-  "description": "Schema to validate v1.6.0 specifications",
+  "title": "Flatcar Linux Butane Schema",
+  "description": "Schema to validate v1.1.0 specifications",
   "additionalProperties": false,
   
   "definitions": {
@@ -219,7 +219,7 @@
   "properties": {
     "variant": {},
     "version": {
-      "description": "The semantic version of the spec for this document. This document is for version 1.6.0 and generates Ignition configs with version 3.5.0."
+      "description": "The semantic version of the spec for this document. This document is for version 1.1.0 and generates Ignition configs with version 3.4.0."
     },
     "ignition": {
       "$id": "#/properties/ignition",

--- a/flatcar-v1.1.0/butane-flatcar-v1.1.0.json
+++ b/flatcar-v1.1.0/butane-flatcar-v1.1.0.json
@@ -1,0 +1,1049 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/Relativ-IT/Butane-Schemas/Release/flatcar-v1.1.0/butane-flatcar-v1.1.0.json#",
+  "$comment": "Sources: https://github.com/Relativ-IT/Butane-Schemas/tree/Release/flatcar-v1.1.0",
+  "type": "object",
+  "title": "Fedora Coreos Butane Schema",
+  "description": "Schema to validate v1.6.0 specifications",
+  "additionalProperties": false,
+  
+  "definitions": {
+    "contents": {
+      "$id": "#/definitions/contents",
+      "type": "object",
+      "additionalItems": false,
+      "oneOf": [
+        { "required": ["source"] },
+        { "required": ["inline"] },
+        { "required": ["local"] }
+      ],
+      "properties": {
+        "compression": {
+          "type": "string",
+          "title": "compression (string):",
+          "description": "The type of compression used on the file (null or gzip). Compression cannot be used with S3.",
+          "enum": ["null","gzip"]
+        },
+        "http_headers": {
+          "$ref": "#/definitions/http_headers"
+        },
+        "verification": {
+          "$ref": "#/definitions/verification",
+          "description": "Options related to the verification of the contents."
+        },
+        "source": {
+          "$ref": "#/definitions/patterns/patternProperties/source_pattern",
+          "type": "string",
+          "title": "source (string):",
+          "description": "The URL of the file. Supported schemes are `http`, `https`, `tftp`, `s3`, `arn`, `gs`, and `data`( https://tools.ietf.org/html/rfc2397 ). When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created. Mutually exclusive with `inline` and `local`."
+        },
+        "inline": {
+          "type": "string",
+          "title": "inline (string):",
+          "description": "The contents. Mutually exclusive with source and local."
+        },
+        "local": {
+          "type": "string",
+          "title": "local (string):",
+          "description": "A local path to the contents, relative to the directory specified by the --files-dir command-line argument. Mutually exclusive with source and inline."
+        }
+      }
+    },
+    "verification": {
+      "$id": "#/definitions/verification",
+      "type": "object",
+      "title": "verification (object):",
+      "description": "Options related to the verification",
+      "additionalProperties": false,
+      "required": ["hash"],
+      "properties": {
+        "hash": {
+          "$id": "#/definitions/verification/hash",
+          "type": "string",
+          "title": "hash (string):",
+          "description": "The hash of the file, in the form `<type>-<value>` where type is either `sha512` or `sha256`. If `compression` is specified, the hash describes the decompressed file.",
+          "pattern": "^(sha256-|sha512-)\\S+$"
+        }
+      }
+    },
+    "http_headers": {
+      "$id": "#/definitions/http_headers",
+      "type": "array",
+      "title": "http_headers (list of objects):",
+      "description": "A list of HTTP headers to be added to the request. Available for http and https source schemes only.",
+      "additionalItems": false,
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "type": "object",
+            "required": ["name"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "name (string):",
+                "description": "The header name."
+              },
+              "value": {
+                "type": "string",
+                "title": "value (string):",
+                "description": "The header contents."
+              }
+            }
+          }
+        ]
+      }
+    },
+    "patterns":{
+      "patternProperties": {
+        "source_pattern": {
+          "$id": "#/definitions/patterns/patternProperties/source_pattern",
+          "pattern": "^((tftp|http|https|s3|gs):\/\/|data:|arn:)[^ \"]+$"
+        },
+        "guid_pattern": {
+          "$id": "#/definitions/patterns/patternProperties/guid_pattern",
+          "pattern": "^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$"
+        },
+        "service_name": {
+          "$id": "#/definitions/patterns/patternProperties/service_name",
+          "pattern": "\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$"
+        },
+        "dropin_name": {
+          "$id": "#/definitions/patterns/patternProperties/dropin_name",
+          "pattern": "(.conf)$"
+        },
+        "ssh_pub": {
+          "$id": "#/definitions/patterns/patternProperties/ssh_pub",
+          "pattern": "((.*)\\s)?((?:sk-)?(?:ssh|ecdsa)-[a-z0-9@.-]+)\\s([a-zA-Z0-9+/]+={0,2})(\\s(.*))?"
+        }
+      }
+    },
+    "string_options": {
+      "$id": "#/definitions/string_options",
+      "type": "array",
+      "additionalItems": false,
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "security_object": {
+      "$id": "#/definitions/security_object",
+      "type": "object",
+      "additionalItems": false,
+      "oneOf": [
+        {"required": ["id"]},
+        {"required": ["name"]}
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "title": "id (integer):"
+        },
+        "name": {
+          "type": "string",
+          "title": "name (string):"
+        }
+      }
+    },
+    "user": {
+      "$id": "#/definitions/user",
+      "$ref": "#/definitions/security_object",
+      "title": "user (object):",
+      "description": "specifies the owner.",
+      "properties": {
+        "id": {
+          "description": "The user ID of the owner."
+        },
+        "name": {
+          "description": "The user name of the owner."
+        }
+      }
+    },
+    "group": {
+      "$id": "#/definitions/group",
+      "$ref": "#/definitions/security_object",
+      "title": "group (object):",
+      "description": "specifies the group of the owner.",
+      "properties": {
+        "id": {
+          "description": "The group ID of the owner."
+        },
+        "name": {
+          "description": "The group name of the owner."
+        }
+      }
+    },
+    "tang":{
+      "$id": "#/definitions/tang",
+      "type": "array",
+      "title": "tang (list of objects):",
+      "description": "Describes a tang server. Every server must have a unique url.",
+      "additionalItems": false,
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "required": ["url","thumbprint"],
+            "additionalProperties": false,
+            "properties": {
+              "url": {
+                "type": "string",
+                "title": "url (string):",
+                "description": "Url of the tang server."
+              },
+              "thumbprint": {
+                "type": "string",
+                "title": "thumbprint (string):",
+                "description": "Thumbprint of a trusted signing key."
+              },
+              "advertisement": {
+                "type": "string",
+                "title": "thumbprint (string):",
+                "description": "The advertisement JSON. If not specified, the advertisement is fetched from the tang server during provisioning."
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "properties": {
+    "variant": {},
+    "version": {
+      "description": "The semantic version of the spec for this document. This document is for version 1.6.0 and generates Ignition configs with version 3.5.0."
+    },
+    "ignition": {
+      "$id": "#/properties/ignition",
+      "type": "object",
+      "title": "ignition (object):",
+      "description": "Metadata about the configuration itself.",
+      "additionalProperties": false,
+      "properties": {
+        "config": {
+          "type": "object",
+          "title": "config (objects):",
+          "description": "Options related to the configuration.",
+          "additionalProperties": false,
+          "properties": {
+            "merge": {
+              "type": "array",
+              "title": "merge (list of objects):",
+              "description": "A list of the configs to be merged to the current config.",
+              "additionalItems": false,
+              "uniqueItems": true,
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/contents"
+              }
+            },
+            "replace": {
+              "title": "replace (object):",
+              "description": "The config that will replace the current.",
+              "$ref": "#/definitions/contents"
+            }
+          }
+        },
+        "timeouts": {
+          "type": "object",
+          "title": "timeouts (object):",
+          "description": "Options relating to http timeouts when fetching files over http or https.",
+          "additionalProperties": false,
+          "properties": {
+            "http_response_headers": {
+              "type": "integer",
+              "title": "http_response_headers (integer):",
+              "description": "The time to wait (in seconds) for the server’s response headers (but not the body) after making a request. 0 indicates no timeout. Default is 10 seconds.",
+              "default": 10
+            },
+            "http_total": {
+              "type": "integer",
+              "title": "http_total (integer):",
+              "description": "The time limit (in seconds) for the operation (connection, request, and response), including retries. 0 indicates no timeout. Default is 0.",
+              "default": 0
+            }
+          }
+        },
+        "security": {
+          "type": "object",
+          "title": "security (object):",
+          "description": "Options relating to network security.",
+          "additionalProperties": false,
+          "required": ["tls"],
+          "properties": {
+            "tls": {
+              "type": "object",
+              "title": "tls (object):",
+              "description": "Options relating to TLS when fetching resources over https.",
+              "additionalProperties": false,
+              "required": ["certificate_authorities"],
+              "properties": {
+                "certificate_authorities": {
+                  "type": "array",
+                  "title": "certificate_authorities (list of objects):",
+                  "description": "The list of additional certificate authorities (in addition to the system authorities) to be used for TLS verification when fetching over https. All certificate authorities must have a unique source, inline, or local.",
+                  "additionalItems": false,
+                  "uniqueItems": true,
+                  "minItems": 1,
+                  "items": {
+                    "$ref": "#/definitions/contents"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "proxy": {
+          "type": "object",
+          "title": "proxy (object):",
+          "description": "Options relating to setting an HTTP(S) proxy when fetching resources.",
+          "additionalProperties": false,
+          "properties": {
+            "http_proxy": {
+              "type": "string",
+              "title": "http_proxy (string):",
+              "description": "Will be used as the proxy URL for HTTP requests and HTTPS requests unless overridden by https_proxy or no_proxy."
+            },
+            "https_proxy": {
+              "type": "string",
+              "title": "https_proxy (string):",
+              "description": "Will be used as the proxy URL for HTTPS requests unless overridden by no_proxy."
+            },
+            "no_proxy": {
+              "$ref": "#/definitions/string_options",
+              "title": "no_proxy (list of strings):",
+              "description": "Specifies a list of strings to hosts that should be excluded from proxying. Each value is represented by an IP address prefix (1.2.3.4), an IP address prefix in CIDR notation (1.2.3.4/8), a domain name, or a special DNS label (*). An IP address prefix and domain name can also include a literal port number (1.2.3.4:80). A domain name matches that name and all subdomains. A domain name with a leading . matches subdomains only. For example foo.com matches foo.com and bar.foo.com; .y.com matches x.y.com but not y.com. A single asterisk (*) indicates that no proxying should be done."
+            }
+          }
+        }
+      }
+    },
+    "storage": {
+      "$id": "#/properties/storage",
+      "type": "object",
+      "title": "storage (object):",
+      "description": "Describes the desired state of the system’s storage devices.",
+      "additionalProperties": false,
+      "properties": {
+        "disks": {
+          "type": "array",
+          "title": "disks (list of objects):",
+          "description": "The list of disks to be configured and their options. Every entry must have a unique device.",
+          "additionalItems": false,
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "required": ["device"],
+                "additionalProperties": false,
+                "properties": {
+                  "device": {
+                    "type": "string",
+                    "title": "device (string):",
+                    "description": "The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks."
+                  },
+                  "wipe_table": {
+                    "type": "boolean",
+                    "title": "wipe_table (boolean):",
+                    "description": "Whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.",
+                    "default": false
+                  },
+                  "partitions": {
+                    "type": "array",
+                    "title": "partitions (list of objects):",
+                    "description": "The list of partitions and their configuration for this particular disk. Every partition must have a unique number, or if 0 is specified, a unique label.",
+                    "additionalItems": false,
+                    "uniqueItems": true,
+                    "minItems": 1,
+                    "items": {
+                      "oneOf": [
+                        {
+                          "additionalProperties": false,
+                          "properties": {
+                            "label": {
+                              "type": "string",
+                              "title": "label (string):",
+                              "description": "The PARTLABEL for the partition."
+                            },
+                            "number": {
+                              "type": "integer",
+                              "title": "number (integer):",
+                              "description": "The partition number, which dictates it’s position in the partition table (one-indexed). If zero, use the next available partition slot.",
+                              "default": 0
+                            },
+                            "size_mib": {
+                              "type": "integer",
+                              "title": "size_mib (integer):",
+                              "description": "The size of the partition (in mebibytes). If zero, the partition will be made as large as possible.",
+                              "default": 0
+                            },
+                            "start_mib": {
+                              "type": "integer",
+                              "title": "start_mib (integer):",
+                              "description": "The start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.",
+                              "default": 0
+                            },
+                            "type_guid": {
+                              "$ref": "#/definitions/patterns/patternProperties/guid_pattern",
+                              "type": "string",
+                              "title": "type_guid (string):",
+                              "description": "The GPT partition type GUID ( https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs ). If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).",
+                              "default": "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
+                            },
+                            "guid": {
+                              "$ref": "#/definitions/patterns/patternProperties/guid_pattern",
+                              "type": "string",
+                              "title": "guid (string):",
+                              "description": "The GPT unique partition GUID."
+                            },
+                            "wipe_partition_entry": {
+                              "type": "boolean",
+                              "title": "wipe_partition_entry (boolean):",
+                              "description": "If true, Ignition will clobber an existing partition if it does not match the config. If false (default), Ignition will fail instead."
+                            },
+                            "should_exist": {
+                              "type": "boolean",
+                              "title": "should_exist (boolean):",
+                              "description": "Whether or not the partition with the specified number should exist. If omitted, it defaults to true. If false Ignition will either delete the specified partition or fail, depending on wipePartitionEntry. If false number must be specified and non-zero and label, start, size, guid, and typeGuid must all be omitted."
+                            },
+                            "resize": {
+                              "type": "boolean",
+                              "title": "resize (boolean):",
+                              "description": "Whether or not the existing partition should be resized. If omitted, it defaults to false. If true, Ignition will resize an existing partition if it matches the config in all respects except the partition size."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "raid": {
+          "type": "array",
+          "title": "raid (list of objects):",
+          "description": "The list of RAID arrays to be configured. Every RAID array must have a unique name.",
+          "additionalItems": false,
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "required": ["name","level","devices"],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "name (string):",
+                    "description": "The name to use for the resulting md device."
+                  },
+                  "level": {
+                    "type": "string",
+                    "title": "level (string):",
+                    "description": "The redundancy level of the array (e.g. linear, raid1, raid5, etc.).",
+                    "enum": ["linear","raid0","0","stripe","raid1","1","mirror","raid4","4","raid5","5","raid6","6","raid10","10"]
+                  },
+                  "devices": {
+                    "$ref": "#/definitions/string_options",
+                    "title": "devices (list of strings):",
+                    "description": "The list of devices (referenced by their absolute path) in the array."
+                  },
+                  "spares": {
+                    "type": "integer",
+                    "title": "spares (integer):",
+                    "description": "The number of spares (if applicable) in the array."
+                  },
+                  "options": {
+                    "$ref": "#/definitions/string_options",
+                    "title": "options (list of strings):",
+                    "description": "Any additional options to be passed to mdadm."
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "filesystems": {
+          "type": "array",
+          "title": "filesystems (list of objects):",
+          "description": "The list of filesystems to be configured. device and format need to be specified. Every filesystem must have a unique device.",
+          "additionalItems": false,
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "required": ["device","format"],
+                "additionalProperties": false,
+                "properties": {
+                  "device": {
+                    "type": "string",
+                    "title": "device (string):",
+                    "description": "The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks."
+                  },
+                  "format": {
+                    "type": "string",
+                    "title": "format (string):",
+                    "description": "The filesystem format (ext4, btrfs, xfs, vfat, swap, or none).",
+                    "enum": ["ext4","btrfs","xfs","vfat","swap","none"]
+                  },
+                  "path": {
+                    "type": "string",
+                    "title": "path (string):",
+                    "description": "The mount-point of the filesystem while Ignition is running relative to where the root filesystem will be mounted. This is not necessarily the same as where it should be mounted in the real root, but it is encouraged to make it the same."
+                  },
+                  "wipe_filesystem": {
+                    "type": "boolean",
+                    "title": "wipe_filesystem (boolean):",
+                    "description": "Whether or not to wipe the device before filesystem creation, see the documentation on filesystems for more information. Defaults to false."
+                  },
+                  "label": {
+                    "type": "string",
+                    "title": "label (string):",
+                    "description": "The label of the filesystem."
+                  },
+                  "uuid": {
+                    "$ref": "#/definitions/patterns/patternProperties/guid_pattern",
+                    "format": "uuid",
+                    "type": "string",
+                    "title": "uuid (string):",
+                    "description": "The uuid of the filesystem."
+                  },
+                  "options": {
+                    "$ref": "#/definitions/string_options",
+                    "title": "options (list of strings):",
+                    "description": "Any additional options to be passed to the format-specific mkfs utility."
+                  },
+                  "mount_options": {
+                    "$ref": "#/definitions/string_options",
+                    "title": "mount_options (list of strings):",
+                    "description": "Any special options to be passed to the mount command."
+                  },
+                  "with_mount_unit": {
+                    "type": "boolean",
+                    "title": "with_mount_unit (boolean):",
+                    "description": "Whether to additionally generate a generic mount unit for this filesystem or a swap unit for this swap area. If a more specific unit is needed, a custom one can be specified in the systemd.units section. The unit will be named with the escaped version of the path or device, depending on the unit type. If your filesystem is located on a Tang-backed LUKS device, the unit will automatically require network access if you specify the device as /dev/mapper/<device-name> or /dev/disk/by-id/dm-name-<device-name>."
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "files": {
+          "type": "array",
+          "title": "files (list of objects):",
+          "description": "The list of files to be written. Every file, directory and link must have a unique path.",
+          "additionalItems": false,
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "required": ["path"],
+                "additionalProperties": false,
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "path (string):",
+                    "description": "The absolute path to the file."
+                  },
+                  "overwrite": {
+                    "type": "boolean",
+                    "title": "overwrite (boolean):",
+                    "description": "Whether to delete preexisting nodes at the path. contents must be specified if overwrite is true. Defaults to false."
+                  },
+                  "contents": {
+                    "$ref": "#/definitions/contents",
+                    "title": "contents (object):",
+                    "description": "Options related to the contents of the file."
+                  },
+                  "append": {
+                    "type": "array",
+                    "title": "append (object):",
+                    "description": "List of fragments to be appended to the file. Follows the same structure as `contents`.",
+                    "additionalItems": false,
+                    "uniqueItems": true,
+                    "minItems": 1,
+                    "items": {
+                      "oneOf": [
+                        {
+                          "$ref": "#/definitions/contents"
+                        }
+                      ]
+                    }
+                  },
+                  "mode": {
+                    "type": "integer",
+                    "title": "mode (integer):",
+                    "description": "The file's permission mode. Setuid/setgid/sticky bits are supported. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents` is unspecified, and a file already exists at the path."
+                  },
+                  "user": {
+                    "$ref": "#/definitions/user"
+                  },
+                  "group": {
+                    "$ref": "#/definitions/group"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "directories": {
+          "type": "array",
+          "title": "directories (list of objects):",
+          "description": "The list of directories to be created. Every file, directory, and link must have a unique path.",
+          "additionalItems": false,
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "required": ["path"],
+                "additionalProperties": false,
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "path (string):",
+                    "description": "The absolute path to the directory."
+                  },
+                  "overwrite": {
+                    "type": "boolean",
+                    "title": "overwrite (boolean):",
+                    "description": "Whether to delete preexisting nodes at the path. contents must be specified if overwrite is true. Defaults to false."
+                  },
+                  "mode": {
+                    "type": "integer",
+                    "title": "mode (integer):",
+                    "description": "The directory's permission mode. Setuid/setgid/sticky bits are supported. If not specified, the permission mode for directories defaults to 0755 or the mode of an existing directory if `overwrite` is false and a directory already exists at the path."
+                  },
+                  "user": {
+                    "$ref": "#/definitions/user"
+                  },
+                  "group": {
+                    "$ref": "#/definitions/group"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "links": {
+          "type": "array",
+          "title": "links (list of objects):",
+          "description": "The list of links to be created. Every file, directory, and link must have a unique path.",
+          "additionalItems": false,
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "required": ["path"],
+                "additionalProperties": false,
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "title": "path (string):",
+                    "description": "The absolute path to the link."
+                  },
+                  "overwrite": {
+                    "type": "boolean",
+                    "title": "overwrite (boolean):",
+                    "description": "Whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false."
+                  },
+                  "user": {
+                    "$ref": "#/definitions/user",
+                    "description": "Specifies the owner for a symbolic link. Ignored for hard links."
+                  },
+                  "group": {
+                    "$ref": "#/definitions/group",
+                    "description": "Specifies the group for a symbolic link. Ignored for hard links."
+                  },
+                  "target": {
+                    "type": "string",
+                    "title": "target (string):",
+                    "description": "The target path of the link"
+                  },
+                  "hard": {
+                    "type": "boolean",
+                    "title": "hard (boolean):",
+                    "description": "A symbolic link is created if this is false, a hard one if this is true."
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "luks": {
+          "$id": "#/properties/storage/luks",
+          "type": "array",
+          "title": "luks (list of objects):",
+          "description": "The list of files to be written. Every file, directory and link must have a unique path.",
+          "additionalItems": false,
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "required": ["name","device"],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "name (string):",
+                    "description": "The name of the luks device."
+                  },
+                  "device": {
+                    "type": "string",
+                    "title": "device (string):",
+                    "description": "The absolute path to the device. Devices are typically referenced by the /dev/disk/by-* symlinks."
+                  },
+                  "key_file": {
+                    "$ref": "#/definitions/contents",
+                    "title": "key_file (object):",
+                    "description": "Options related to the contents of the key file."
+                  },
+                  "label": {
+                    "type": "string",
+                    "title": "label (string):",
+                    "description": "The label of the luks device."
+                  },
+                  "uuid": {
+                    "$ref": "#/definitions/patterns/patternProperties/guid_pattern",
+                    "type": "string",
+                    "title": "uuid (string):",
+                    "description": "The uuid of the luks device."
+                  },
+                  "options": {
+                    "$ref": "#/definitions/string_options",
+                    "title": "options (list of strings):",
+                    "description": "Any additional options to be passed to the cryptsetup utility."
+                  },
+                  "discard": {
+                    "type": "boolean",
+                    "title": "wipe_volume (boolean):",
+                    "description": "Whether to issue discard commands to the underlying block device when blocks are freed. Enabling this improves performance and device longevity on SSDs and space utilization on thinly provisioned SAN devices, but leaks information about which disk blocks contain data. If omitted, it defaults to false."
+                  },
+                  "open_options": {
+                    "$ref": "#/definitions/string_options",
+                    "title": "options (list of strings):",
+                    "description": "Any additional options to be passed to cryptsetup luksOpen. Supported options will be persistently written to the luks volume."
+                  },
+                  "wipe_volume": {
+                    "type": "boolean",
+                    "title": "wipe_volume (boolean):",
+                    "description": "Whether or not to wipe the device before volume creation, see the Ignition documentation on filesystems for more information."
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "trees": {
+          "type": "array",
+          "title": "trees (list of objects):",
+          "description": "A list of local directory trees to be embedded in the config. Ownership is not preserved. File modes are set to 0755 if the local file is executable or 0644 otherwise. Attributes of files, directories, and symlinks can be overridden by creating a corresponding entry in the files, directories, or links section; such files entries must omit contents and such links entries must omit target.",
+          "additionalItems": false,
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "required": ["local"],
+                "additionalProperties": false,
+                "properties": {
+                  "local": {
+                    "type": "string",
+                    "title": "local (string):",
+                    "description": "The base of the local directory tree, relative to the directory specified by the --files-dir command-line argument."
+                  },
+                  "path": {
+                    "type": "string",
+                    "title": "path (string):",
+                    "description": "The path of the tree within the target system. Defaults to /."
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "systemd": {
+      "$id": "#/properties/systemd",
+      "type": "object",
+      "title": "systemd (object):",
+      "description": "Describes the desired state of the systemd units.",
+      "additionalProperties": false,
+      "properties": {
+        "units": {
+          "type": "array",
+          "title": "units (list of objects):",
+          "description": "The list of systemd units. Every unit must have a unique name.",
+          "additionalItems": false,
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "required": ["name"],
+                "additionalProperties": false,
+                "dependencies": {
+                  "contents": { "not": { "required": ["contents_local"] } },
+                  "contents_local": { "not": { "required": ["contents"] } }
+                },
+                "properties": {
+                  "name": {
+                    "$ref": "#/definitions/patterns/patternProperties/service_name",
+                    "type": "string",
+                    "title": "name (string):",
+                    "description": "The name of the unit. This must be suffixed with a valid unit type (e.g. “thing.service”)."
+                  },
+                  "enabled": {
+                    "type": "boolean",
+                    "title": "enabled (boolean):",
+                    "description": "Whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section."
+                  },
+                  "mask": {
+                    "type": "boolean",
+                    "title": "enabled (boolean):",
+                    "description": "Whether or not the service shall be masked. When true, the service is masked by symlinking it to /dev/null. When false, the service is unmasked by deleting the symlink to `/dev/null` if it exists."
+                  },
+                  "contents": {
+                    "type": "string",
+                    "title": "contents (string):",
+                    "description": "The contents of the unit. Mutually exclusive with `contents_local`."
+                  },
+                  "contents_local": {
+                    "type": "string",
+                    "title": "contents (string):",
+                    "description": "A local path to the contents of the unit, relative to the directory specified by the --files-dir command-line argument. Mutually exclusive with contents."
+                  },
+                  "dropins": {
+                    "type": "array",
+                    "title": "dropins (list of objects):",
+                    "description": "The list of drop-ins for the unit. Every drop-in must have a unique name.",
+                    "additionalItems": false,
+                    "uniqueItems": true,
+                    "minItems": 1,
+                    "items": {
+                      "oneOf": [
+                        {
+                          "required": ["name"],
+                          "additionalProperties": false,
+                          "oneOf": [
+                            { "required": ["contents"] },
+                            { "required": ["contents_local"] }
+                          ],
+                          "properties": {
+                            "name": {
+                              "$ref": "#/definitions/patterns/patternProperties/dropin_name",
+                              "type": "string",
+                              "title": "name (string):",
+                              "description": "The name of the drop-in. This must be suffixed with '.conf'."
+                            },
+                            "contents": {
+                              "type": "string",
+                              "title": "contents (string):",
+                              "description": "The contents of the drop-in. Mutually exclusive with contents_local."
+                            },
+                            "contents_local": {
+                              "type": "string",
+                              "title": "contents (string):",
+                              "description": "A local path to the contents of the drop-in, relative to the directory specified by the --files-dir command-line argument. Mutually exclusive with contents."
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "passwd": {
+      "$id": "#/properties/passwd",
+      "type": "object",
+      "title": "passwd (object):",
+      "description": "Describes the desired additions to the passwd database.",
+      "additionalProperties": false,
+      "properties": {
+        "users": {
+          "type": "array",
+          "title": "users (list of objects):",
+          "description": "The list of accounts that shall exist. All users must have a unique name.",
+          "additionalItems": false,
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "required": ["name"],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "name (string):",
+                    "description": "The username for the account."
+                  },
+                  "password_hash": {
+                    "type": "string",
+                    "title": "password_hash (string):",
+                    "description": "The hashed password for the account."
+                  },
+                  "ssh_authorized_keys": {
+                    "$ref": "#/definitions/string_options",
+                    "title": "ssh_authorized_keys (list of strings):",
+                    "description": "A list of SSH keys to be added as an SSH key fragment at .ssh/authorized_keys.d/ignition in the user’s home directory. All SSH keys must be unique.",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "$ref": "#/definitions/patterns/patternProperties/ssh_pub"
+                        }
+                      ]
+                    }
+                  },
+                  "ssh_authorized_keys_local": {
+                    "$ref": "#/definitions/string_options",
+                    "title": "ssh_authorized_keys_local (list of strings):",
+                    "description": "A list of local paths to SSH key files, relative to the directory specified by the --files-dir command-line argument, to be added as SSH key fragments at .ssh/authorized_keys.d/ignition in the user's home directory. All SSH keys must be unique. Each file may contain multiple SSH keys, one per line."
+                  },
+                  "uid": {
+                    "type": "integer",
+                    "title": "uid (integer):",
+                    "description": "The user ID of the account."
+                  },
+                  "gecos": {
+                    "type": "string",
+                    "title": "gecos (string):",
+                    "description": "The GECOS field of the account."
+                  },
+                  "home_dir": {
+                    "type": "string",
+                    "title": "home_dir (string):",
+                    "description": "The home directory of the account."
+                  },
+                  "no_create_home": {
+                    "type": "boolean",
+                    "title": "no_create_home (boolean):",
+                    "description": "Whether or not to create the user’s home directory. This only has an effect if the account doesn’t exist yet."
+                  },
+                  "primary_group": {
+                    "type": "string",
+                    "title": "primary_group (string):",
+                    "description": "The name of the primary group of the account."
+                  },
+                  "groups": {
+                    "$ref": "#/definitions/string_options",
+                    "title": "groups (list of strings):",
+                    "description": "The list of supplementary groups of the account."
+                  },
+                  "no_user_group": {
+                    "type": "boolean",
+                    "title": "no_user_group (boolean):",
+                    "description": "Whether or not to create a group with the same name as the user. This only has an effect if the account doesn’t exist yet."
+                  },
+                  "no_log_init": {
+                    "type": "boolean",
+                    "title": "no_log_init (boolean):",
+                    "description": "Whether or not to add the user to the lastlog and faillog databases. This only has an effect if the account doesn’t exist yet."
+                  },
+                  "shell": {
+                    "type": "string",
+                    "title": "shell (string):",
+                    "description": "The login shell of the new account."
+                  },
+                  "system": {
+                    "type": "boolean",
+                    "title": "system (boolean):",
+                    "description": "Whether or not this account should be a system account. This only has an effect if the account doesn’t exist yet."
+                  },
+                  "should_exist": {
+                    "type":"boolean",
+                    "title": "should_exist (boolean)",
+                    "description": "Whether or not the user with the specified name should exist. If omitted, it defaults to true. If false, then Ignition will delete the specified user."
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "groups": {
+          "type": "array",
+          "title": "groups (list of objects):",
+          "description": "The list of groups to be added. All groups must have a unique name.",
+          "additionalItems": false,
+          "uniqueItems": true,
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "required": ["name"],
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "title": "name (string):",
+                    "description": "The name of the group."
+                  },
+                  "gid": {
+                    "type": "integer",
+                    "title": "gid (integer):",
+                    "description": "The group ID of the new group."
+                  },
+                  "password_hash": {
+                    "type": "string",
+                    "title": "password_hash (string):",
+                    "description": "The hashed password of the new group."
+                  },
+                  "system": {
+                    "type": "boolean",
+                    "title": "system (boolean):",
+                    "description": "Whether or not the group should be a system group. This only has an effect if the group doesn’t exist yet."
+                  },
+                  "should_exist": {
+                    "type":"boolean",
+                    "title": "should_exist (boolean)",
+                    "description": "Whether or not the group with the specified name should exist. If omitted, it defaults to true. If false, then Ignition will delete the specified group."
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "kernel_arguments": {
+      "$id": "#/properties/kernel_arguments",
+      "type": "object",
+      "title": "kernel_arguments (object):",
+      "description": "Describes the desired kernel arguments.",
+      "additionalProperties": false,
+      "properties": {
+        "should_exist": {
+          "$ref": "#/definitions/string_options",
+          "title": "should_exist (list of strings):",
+          "description": "The list of kernel arguments that should exist."
+        },
+        "should_not_exist": {
+          "$ref": "#/definitions/string_options",
+          "title": "should_not_exist (list of strings):",
+          "description": "The list of kernel arguments that should not exist."
+        }
+      }
+    }
+  }
+}

--- a/flatcar-v1.1.0/testconfig.bu
+++ b/flatcar-v1.1.0/testconfig.bu
@@ -1,0 +1,218 @@
+# yaml-language-server: $schema=../Butane-Schema-dev.json
+variant: flatcar
+version: 1.1.0
+
+ignition:
+  config:
+    merge:
+      - source: https://example.com/etc/hosts
+        http_headers:
+          - name: Authorization
+            value: Basic YWxhZGRpbjpvcGVuc2VzYW1l
+          - name: User-Agent
+            value: Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1)
+        verification:
+          hash: sha256-702d8a08044b106d73a1ff8f1636e3b410d5bc1f9bed5afb99981ec5f97c4a66
+      - inline : |
+          "some inline config
+          on multiple lines"
+
+    replace:
+      source: "https://example.com/replacement.ign"
+      http_headers:
+        - name: Authorization
+          value: Basic YWxhZGRpbjpvcGVuc2VzYW1l
+        - name: User-Agent
+          value: Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1)
+      verification:
+        hash: sha256-702d8a08044b106d73a1ff8f1636e3b410d5bc1f9bed5afb99981ec5f97c4a66
+
+  timeouts:
+    http_response_headers : 10
+    http_total : 0
+
+  security:
+    tls:
+      certificate_authorities :
+        - source: http://www.cacert.org/certs/root_X0F.crt
+          http_headers:
+            - name: Authorization
+              value: Basic YWxhZGRpbjpvcGVuc2VzYW1l
+            - name: User-Agent
+              value: Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1)
+          verification:
+            hash: sha256-702d8a08044b106d73a1ff8f1636e3b410d5bc1f9bed5afb99981ec5f97c4a66
+        - inline: PEM
+
+  proxy:
+    http_proxy: "http://proxy"
+    https_proxy: "https://proxy"
+    no_proxy:
+      - 10.10.10.10
+      - service.local
+
+storage:
+  disks:
+  - device: /dev/sda
+    wipe_table: false
+    partitions:
+    - number: 4
+      label: root
+      size_mib: 8192
+      resize: true
+    - size_mib: 0
+      label: Var
+  - device: /dev/sdb
+    wipe_table: true
+    partitions:
+      - number: 2
+        label: boot
+        size_mib: 8192
+        resize: false
+      - size_mib: 0
+        number: 3
+        label: etc
+        type_guid: 0FC63DAF-8483-4772-8E79-3D69D8477DE4
+
+  raid:
+    - name: Raid
+      level: mirror
+      devices:
+        - /dev/disk/by-id/ata-WDC_WD10SPZX-80Z10T2_WD-WX41A49H9FT4
+        - /dev/disk/by-id/ata-WDC_WD10SPZX-80Z10T2_WD-WXL1A49KPYFD
+      options:
+        - --config=/etc/mdadm.conf
+        - --assume-clean
+        - --uuid=7ec8d4df:823fae52:c55d5e56:e773b281
+
+  filesystems:
+    - path: /var
+      device: /dev/md/Raid
+      format: xfs
+      label: Var
+      wipe_filesystem: false
+      uuid: a1bdb8c9-cdb7-cbec-af9b-34c5facfb00c
+      options:
+        - --optiontomkfs
+      mount_options:
+        - --mountoption
+      with_mount_unit: true
+
+    - device: /dev/disk/by-partlabel/swap
+      format: swap
+      wipe_filesystem: true
+      with_mount_unit: true
+
+  files:
+    - path: /etc/hostname
+      mode : 0644
+      contents:
+        inline: hostname
+      user:
+        name: core
+      group:
+        name: wheel
+
+    - path: /opt/file2
+      contents:
+        source: arn:example.com/file2
+        compression: gzip
+        verification:
+          hash: sha512-4ee6a9d20cc0e6c7ee187daffa6822bdef7f4cebe109eff44b235f97e45dc3d7a5bb932efc841192e46618f48a6f4f5bc0d15fd74b1038abf46bf4b4fd409f2e
+      mode: 0644
+
+    - path: /opt/file
+      contents:
+        inline: Hello, world!
+      mode: 0644
+      user:
+        id: 500
+      group:
+        id: 501
+
+  luks:
+    - name: static-key-example
+      device: /dev/sdb
+      key_file:
+        inline: REPLACE-THIS-WITH-YOUR-KEY-MATERIAL
+      discard: false
+    - name: tpm-example
+      device: /dev/sdc
+    - name: tang-example
+      device: /dev/sdd
+      discard: true
+
+  trees:
+    - local: v1.5.0
+
+passwd:
+  users:
+    - name: user1
+      ssh_authorized_keys:
+        - ssh-rsa AAAAB3NzaC1yc2asdfas test@openssh.com
+        - ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT asdfasdf
+        - ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD asdfasdf
+        - ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj test@example.net
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5 testing
+        - sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAI yubikey 5 nfc
+        - ssh-dss AAAAB3NzaC1kc3 oldkey@example.com
+      ssh_authorized_keys_local:
+        - secret/id_ed25519.pub
+        - secret/id_rsa.pub
+      password_hash: $y$j9T$aUmgEDoFIDPhGxEe2FUjc/$C5A...
+      home_dir: /home/user1
+      no_create_home: true
+      groups:
+        - wheel
+        - plugdev
+      shell: /bin/bash
+      should_exist: true
+
+  groups:
+    - name: plugdev
+      should_exist: true
+
+systemd:
+  units:
+    - name: exporter.service
+      enabled: true
+      dropins:
+        - name: dropin.conf
+          contents: some string
+      contents: |
+        [Unit]
+        Description=Prometheus node exporter
+        After=network-online.target
+        Wants=network-online.target
+
+        [Service]
+        Environment=PODMAN_SYSTEMD_UNIT=%n
+        ExecStart=/usr/bin/podman run --label="io.containers.autoupdate=registry" --detach --replace --name=%N --privileged --network=host --pid=host -v /run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:ro -v /:/host:ro,rslave quay.io/prometheus/node-exporter:latest --path.rootfs=/host --collector.systemd
+        ExecStop=/usr/bin/podman stop %N
+        Type=forking
+
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: another-one.service
+      enabled: true
+      dropins:
+        - name: dropin.conf
+          contents_local: /opt/local/dropincontent
+      contents_local: /opt/local/unitcontent
+
+    - name: serial-getty@ttyS0.service
+      dropins:
+        - name: autologin-core.conf
+          contents: |
+            [Service]
+            # Override Execstart in main unit
+            ExecStart=
+            # Add new Execstart with `-` prefix to ignore failure`
+            ExecStart=-/usr/sbin/agetty --autologin core --noclear %I $TERM
+
+kernel_arguments:
+  should_exist:
+    - mitigations=off
+  should_not_exist:
+    - mitigations=auto,nosmt


### PR DESCRIPTION
The schema between Flatcar v1.1.0 and Fedora Core v1.6.0 are very similar, except for the removal of several objects/fields.

See https://gist.github.com/rslarson/12793504e61d6e942691ef317ce9c75a for diff